### PR TITLE
Cache requests for the same set of files

### DIFF
--- a/quickconcat.php
+++ b/quickconcat.php
@@ -2,15 +2,19 @@
 /*
 quickconcat: a simple dynamic concatenator for html, css, and js files
 	Copyright 2012, Scott Jehl, Filament Group, Inc. Dual licensed under MIT and GPLv2
-	*  accepts 2 query strings:
+	*  accepts 3 query strings:
 		* files (required): a comma-separated list of root-relative file paths
 		* wrap (optional): Enclose each result in an element node with url attribute? False by default.
+		* nocache (optional): Do not read from or create a cache file? False by default.
 */
 // List of files, comma-separated paths
 $filelist = $_REQUEST[ "files" ];
 
 // Enclose each result in an element node with url attribute?
 $wrap = isset( $_REQUEST[ "wrap" ] );
+
+// Do not read from or create a cache file?
+$nocache = isset( $_REQUEST[ "nocache" ] );
 
 // Get the filetype and array of files
 if ( ! isset( $filelist ) ) {
@@ -29,7 +33,7 @@ $cache_dir =  __DIR__ . '/.quickconcat-cache';
 $cache_name = $cache_dir . '/' . md5( $filelist . ($wrap ? 'wrap' : '') );
 
 // See if cached copy exists
-if ( file_exists($cache_name) ) {
+if ( ! $nocache && file_exists($cache_name) ) {
 	$contents = file_get_contents($cache_name);
 }
 else {
@@ -44,11 +48,13 @@ else {
 		}
 	}
 
-	// Write out cache file
-	if ( ! is_dir($cache_dir) ) {
-		mkdir($cache_dir);
+	if ( ! $nocache ) {
+		// Write out cache file
+		if ( ! is_dir($cache_dir) ) {
+			mkdir($cache_dir);
+		}
+		file_put_contents($cache_name, $contents);
 	}
-	file_put_contents($cache_name, $contents);
 }
 
 // Set the content type and filesize headers

--- a/quickconcat.php
+++ b/quickconcat.php
@@ -29,8 +29,16 @@ $fext = preg_match( '/\.(js|html|css)$/', $files[ 0 ], $match );
 $ftype = $fext ? $match[ 1 ] : "html";
 $type = "text/" . ( $ftype === "js" ? "javascript" : $ftype );
 
-$cache_dir =  __DIR__ . '/.quickconcat-cache';
-$cache_name = $cache_dir . '/' . md5( $filelist . ($wrap ? 'wrap' : '') );
+if ( ! $nocache ) {
+	// Get file last modified time
+	$cache_string = '';
+	foreach ( $files as $file ) {
+		$cache_string = $file . filemtime($file);
+	}
+
+	$cache_dir =  __DIR__ . '/.quickconcat-cache';
+	$cache_name = $cache_dir . '/' . md5( $cache_string . ($wrap ? 'wrap' : '') );
+}
 
 // See if cached copy exists
 if ( ! $nocache && file_exists($cache_name) ) {

--- a/quickconcat.php
+++ b/quickconcat.php
@@ -2,7 +2,7 @@
 /*
 quickconcat: a simple dynamic concatenator for html, css, and js files
 	Copyright 2012, Scott Jehl, Filament Group, Inc. Dual licensed under MIT and GPLv2
-	*  accepts 2 query strings: 
+	*  accepts 2 query strings:
 		* files (required): a comma-separated list of root-relative file paths
 		* wrap (optional): Enclose each result in an element node with url attribute? False by default.
 */
@@ -13,7 +13,7 @@ $filelist = $_REQUEST[ "files" ];
 $wrap = isset( $_REQUEST[ "wrap" ] );
 
 // Get the filetype and array of files
-if ( ! isset( $filelist ) ){
+if ( ! isset( $filelist ) ) {
 	echo '$files must be specified!';
 	exit;
 }
@@ -25,15 +25,30 @@ $fext = preg_match( '/\.(js|html|css)$/', $files[ 0 ], $match );
 $ftype = $fext ? $match[ 1 ] : "html";
 $type = "text/" . ( $ftype === "js" ? "javascript" : $ftype );
 
-$contents = '';
+$cache_dir =  __DIR__ . '/.quickconcat-cache';
+$cache_name = $cache_dir . '/' . md5( $filelist . ($wrap ? 'wrap' : '') );
 
-// Loop through the files adding them to a string
-foreach ( $files as $file ) {
-	if( preg_match( '/\.(js|html|css)$/', $file ) ){
-		$open = $wrap ? "<entry url=\"". $file . "\">" : "";
-		$close = $wrap ? "</entry>\n" : "";
-		$contents .= $open . file_get_contents($file). $close;
+// See if cached copy exists
+if ( file_exists($cache_name) ) {
+	$contents = file_get_contents($cache_name);
+}
+else {
+	$contents = '';
+
+	// Loop through the files adding them to a string
+	foreach ( $files as $file ) {
+		if ( preg_match( '/\.(js|html|css)$/', $file ) ){
+			$open = $wrap ? "<entry url=\"". $file . "\">" : "";
+			$close = $wrap ? "</entry>\n" : "";
+			$contents .= $open . file_get_contents($file). $close;
+		}
 	}
+
+	// Write out cache file
+	if ( ! is_dir($cache_dir) ) {
+		mkdir($cache_dir);
+	}
+	file_put_contents($cache_name, $contents);
 }
 
 // Set the content type and filesize headers


### PR DESCRIPTION
When a set of files is requested a combined version should be written to a cache. When the same set of files is requested the cached version should be read and sent instead of opening, reading and combining each file again.

A `nocache` query parameter should force the files to be read and combined instead of using the cache (for getting HTML fragments that are dynamically generated).
