### PR TITLE
filter $files when not contained in the current folder or one of its subfolders

### DIFF
--- a/quickconcat.php
+++ b/quickconcat.php
@@ -19,6 +19,17 @@ if ( ! isset( $filelist ) ){
 }
 
 $files = explode( ",", $filelist );
+$appRoot = dirname(__FILE__);
+
+// sanitize file-parameters
+foreach ( $files as $idx => $file ) {
+    // we allow only certain filetypes
+	// all files must be contained in the same folder or in one of our subfolders
+	if( !preg_match( '/\.(js|html|css)$/', $file ) || 
+		strpos(realpath($file), $appRoot) !== 0){
+		unset($files[$idx]);
+	}
+}
 
 // Guess file type
 $fext = preg_match( '/\.(js|html|css)$/', $files[ 0 ], $match );
@@ -29,11 +40,9 @@ $contents = '';
 
 // Loop through the files adding them to a string
 foreach ( $files as $file ) {
-	if( preg_match( '/\.(js|html|css)$/', $file ) ){
-		$open = $wrap ? "<entry url=\"". $file . "\">" : "";
-		$close = $wrap ? "</entry>\n" : "";
-		$contents .= $open . file_get_contents($file). $close;
-	}
+	$open = $wrap ? "<entry url=\"". $file . "\">" : "";
+	$close = $wrap ? "</entry>\n" : "";
+	$contents .= $open . file_get_contents($file). $close;
 }
 
 // Set the content type and filesize headers


### PR DESCRIPTION
fix according to comment: 
https://github.com/filamentgroup/quickconcat/commit/a41ba9a9ab3a6cc431e2c45cc17db54ef3c535b1#commitcomment-1718693

see diff: https://github.com/staabm/quickconcat/compare/sanitize_filenames?w=1
