### PR TITLE
Make sure we guess the file type with an index still set

### DIFF
--- a/quickconcat.php
+++ b/quickconcat.php
@@ -39,7 +39,8 @@ foreach ( $files as $idx => $file ) {
 
 // Find the first index still set
 for ( $idx = 0; ! isset( $files[ $idx ] ); $idx++ )
-	null;
+	if ( $idx > count( $files ) )
+		exit;
 
 // Guess file type
 $fext = preg_match( '/\.(js|html|css)$/', $files[ $idx ], $match );


### PR DESCRIPTION
Ensures we guess the file type with an index that still exists after the sanitize file-parameters loop.

This little for loop:
- starts at the first index
- ends once it finds one still set
- exits if none exist, preventing an infinite loop.

The first set $idx is then used for file type guessing.
